### PR TITLE
Fix deploy: point Maven repository to Repsy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,9 @@ jobs:
           server-username: REPSYS_MAVEN_USERNAME
           server-password: REPSYS_MAVEN_PASSWORD
 
-      - name: Clean up corrupt cached metadata
-        run: |
-          rm -rf ~/.m2/repository/org/openmrs/module/ehospitalws/ || true
-
       - name: Deploy snapshot to Repsys
         run: |
-          mvn --batch-mode deploy -DskipTests \
-            -DrepsysSnapshotsUrl=${{ secrets.REPSYS_SNAPSHOTS_URL }}
+          mvn --batch-mode deploy -DskipTests
         env:
           REPSYS_MAVEN_USERNAME: ${{ secrets.REPSYS_MAVEN_USERNAME }}
           REPSYS_MAVEN_PASSWORD: ${{ secrets.REPSYS_MAVEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,4 @@ jobs:
       - name: Perform Maven release
         run: |
           mvn --batch-mode release:prepare release:perform \
-            -DrepsysReleasesUrl=${{ secrets.REPSYS_RELEASES_URL }} \
-            -DrepsysSnapshotsUrl=${{ secrets.REPSYS_SNAPSHOTS_URL }} \
-            -Darguments="-DskipTests \
-              -DrepsysReleasesUrl=${{ secrets.REPSYS_RELEASES_URL }} \
-              -DrepsysSnapshotsUrl=${{ secrets.REPSYS_SNAPSHOTS_URL }}"
+            -Darguments="-DskipTests"

--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
 		<serializationxstreamVersion>0.2.14</serializationxstreamVersion>
 		<mockito.version>4.5.1</mockito.version>
 		<powermock.version>2.0.9</powermock.version>
-		<repsysReleasesUrl>https://packages.intellisoft.co.ke/repository/maven-releases/</repsysReleasesUrl>
-		<repsysSnapshotsUrl>https://packages.intellisoft.co.ke/repository/maven-snapshots/</repsysSnapshotsUrl>
+		<repsysReleasesUrl>https://repo.repsy.io/intellisoftdev/ehospital/</repsysReleasesUrl>
+		<repsysSnapshotsUrl>https://repo.repsy.io/intellisoftdev/ehospital/</repsysSnapshotsUrl>
     </properties>
 
 	<build>


### PR DESCRIPTION
## Problem
The `Deploy Snapshot` workflow was failing ([run #28078389564](https://github.com/IntelliSOFT-Consulting/openmrs-module-ehospitalws/actions/runs/28078389564)). The build itself succeeded — only the deploy step failed:

```
Could not parse metadata .../maven-metadata-repsys-snapshots.xml:
unexpected markup <!d (position: START_DOCUMENT seen <!d... @1:4)
```

The Nexus host `packages.intellisoft.co.ke` no longer serves a Maven repository — it returns HTML error pages (root → 500, repo paths → 404/200 HTML). When `maven-deploy-plugin` fetched the existing remote `maven-metadata.xml` to merge it, it got a 16 kB HTML page and choked parsing HTML as XML.

## Fix
- **pom.xml** — point `repsysReleasesUrl` and `repsysSnapshotsUrl` to the new Repsy repo `https://repo.repsy.io/intellisoftdev/ehospital/` (Repsy uses one URL for both releases and snapshots).
- **deploy.yml** — drop the stale `-DrepsysSnapshotsUrl` secret override (pointed at the dead host) and the now-unnecessary metadata-cache cleanup step.
- **release.yml** — drop the same stale `REPSYS_*_URL` overrides.

Verified `repo.repsy.io/intellisoftdev/ehospital/` is healthy: the metadata path returns a clean `404` (0 bytes), which Maven treats as "no prior metadata, proceed."

## ⚠️ Follow-up required
The auth secrets still hold the old Nexus credentials. Repsy auth uses a **Repsy username + access token**:
- `REPSYS_MAVEN_USERNAME` → Repsy username
- `REPSYS_MAVEN_PASSWORD` → Repsy access token

If not updated, the deploy will now reach Repsy but fail with **401 Unauthorized**. The `REPSYS_SNAPSHOTS_URL` / `REPSYS_RELEASES_URL` secrets are no longer referenced and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)