### PR TITLE
Fail loudly on missing SMS/admin credentials; tag releases as v<version>

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ehospitalws/service/SmsService.java
+++ b/omod/src/main/java/org/openmrs/module/ehospitalws/service/SmsService.java
@@ -1,6 +1,8 @@
 package org.openmrs.module.ehospitalws.service;
 
 import org.openmrs.module.ehospitalws.util.OpenMRSPropertiesUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
@@ -11,25 +13,39 @@ import java.util.Map;
 
 @Component
 public class SmsService {
-	
+
+	private static final Logger log = LoggerFactory.getLogger(SmsService.class);
+
 	private final String smsApiUrl;
-	
+
 	private final String apiKey;
-	
+
 	private final String partnerId;
-	
+
 	private final String shortcode;
-	
+
+	private final boolean configured;
+
 	public SmsService() {
-		this.smsApiUrl = OpenMRSPropertiesUtil.getProperty("sms.api.url", "https://test.sms.com/api/services/sendsms/");
-		this.apiKey = OpenMRSPropertiesUtil.getProperty("sms.api.key", "default-api-key");
-		this.partnerId = OpenMRSPropertiesUtil.getProperty("sms.partner.id", "default-partner-id");
-		this.shortcode = OpenMRSPropertiesUtil.getProperty("sms.shortcode", "default-shortcode");
+		this.smsApiUrl = OpenMRSPropertiesUtil.getProperty("sms.api.url", null);
+		this.apiKey = OpenMRSPropertiesUtil.getProperty("sms.api.key", null);
+		this.partnerId = OpenMRSPropertiesUtil.getProperty("sms.partner.id", null);
+		this.shortcode = OpenMRSPropertiesUtil.getProperty("sms.shortcode", null);
+		this.configured = smsApiUrl != null && apiKey != null && partnerId != null && shortcode != null;
+		if (!configured) {
+			log.warn("SMS service is not configured. Set sms.api.url, sms.api.key, sms.partner.id and "
+			        + "sms.shortcode in openmrs-runtime.properties. SMS sending is disabled until these are set.");
+		}
 	}
-	
+
 	public boolean sendSms(String phoneNumber, String message) {
+		if (!configured) {
+			log.error("Cannot send SMS to {}: SMS gateway properties are not configured.", phoneNumber);
+			return false;
+		}
+
 		RestTemplate restTemplate = new RestTemplate();
-		
+
 		// Create the request body
 		Map<String, String> requestBody = new HashMap<>();
 		requestBody.put("apikey", apiKey);
@@ -38,14 +54,14 @@ public class SmsService {
 		requestBody.put("message", message);
 		requestBody.put("shortcode", shortcode);
 		requestBody.put("pass_type", "plain");
-		
+
 		try {
 			// Send the POST request
 			ResponseEntity<String> response = restTemplate.postForEntity(smsApiUrl, requestBody, String.class);
 			return response.getStatusCode() == HttpStatus.OK;
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			log.error("Failed to send SMS to {}", phoneNumber, e);
 			return false;
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/ehospitalws/task/ScheduledAppointmentReminderTask.java
+++ b/omod/src/main/java/org/openmrs/module/ehospitalws/task/ScheduledAppointmentReminderTask.java
@@ -62,8 +62,8 @@ public class ScheduledAppointmentReminderTask {
 	public void sendAppointmentReminders() {
 		Context.openSession();
 		try {
-			String adminUsername = OpenMRSPropertiesUtil.getProperty("admin.username", "*****");
-			String adminPassword = OpenMRSPropertiesUtil.getProperty("admin.password", "*****");
+			String adminUsername = OpenMRSPropertiesUtil.getRequiredProperty("admin.username");
+			String adminPassword = OpenMRSPropertiesUtil.getRequiredProperty("admin.password");
 			
 			Context.authenticate(adminUsername, adminPassword);
 			

--- a/omod/src/main/java/org/openmrs/module/ehospitalws/task/SendMessageTask.java
+++ b/omod/src/main/java/org/openmrs/module/ehospitalws/task/SendMessageTask.java
@@ -35,8 +35,8 @@ public class SendMessageTask {
 	public void sendScheduledMessages() {
 		Context.openSession();
 		try {
-			String adminUsername = OpenMRSPropertiesUtil.getProperty("admin.username", "*****");
-			String adminPassword = OpenMRSPropertiesUtil.getProperty("admin.password", "*****");
+			String adminUsername = OpenMRSPropertiesUtil.getRequiredProperty("admin.username");
+			String adminPassword = OpenMRSPropertiesUtil.getRequiredProperty("admin.password");
 			Context.authenticate(adminUsername, adminPassword);
 			
 			log.info("SendMessageTask started.");

--- a/omod/src/main/java/org/openmrs/module/ehospitalws/util/OpenMRSPropertiesUtil.java
+++ b/omod/src/main/java/org/openmrs/module/ehospitalws/util/OpenMRSPropertiesUtil.java
@@ -5,18 +5,36 @@ import org.openmrs.api.context.Context;
 import java.util.Properties;
 
 public class OpenMRSPropertiesUtil {
-	
+
 	public static Properties getProperties() {
 		return Context.getRuntimeProperties();
 	}
-	
-	// Helper method to fetch and trim properties
+
+	/**
+	 * Fetches an optional runtime property, returning the supplied default (trimmed) when the property
+	 * is absent or blank. Use this only for values that have a sensible fallback.
+	 */
 	public static String getProperty(String key, String defaultValue) {
-		Properties properties = getProperties();
-		String value = properties.getProperty(key, defaultValue).trim();
-		if (value.isEmpty()) {
-			throw new IllegalStateException("Missing required OpenMRS property: " + key);
+		String value = getProperties().getProperty(key);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
 		}
-		return value;
+		return value.trim();
+	}
+
+	/**
+	 * Fetches a required runtime property and fails loudly when it is missing or blank, rather than
+	 * silently falling back to a placeholder. Use this for credentials and gateway settings that the
+	 * module cannot function correctly without.
+	 *
+	 * @throws IllegalStateException if the property is not set or is blank
+	 */
+	public static String getRequiredProperty(String key) {
+		String value = getProperties().getProperty(key);
+		if (value == null || value.trim().isEmpty()) {
+			throw new IllegalStateException("Missing required OpenMRS runtime property '" + key
+			        + "'. Set it in openmrs-runtime.properties.");
+		}
+		return value.trim();
 	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,8 @@
 					<autoVersionSubmodules>true</autoVersionSubmodules>
 					<goals>deploy</goals>
 					<arguments>-DskipTests</arguments>
+					<!-- Match the v-prefixed tag convention used for GitHub releases (e.g. v1.0.0) -->
+					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
## Summary

Two follow-up hardening changes:

1. **Stop silently running with placeholder credentials.** `OpenMRSPropertiesUtil.getProperty(key, default)` previously returned non-empty placeholders (`"default-api-key"`, `"*****"`) when a runtime property was missing. The result was a silent footgun: SMS was sent to a test gateway, and the scheduled tasks attempted to authenticate as `*****`, failing with confusing errors instead of a clear "you forgot to configure this" signal.
2. **Make the Maven release tag match the GitHub release convention** (`v1.0.0` instead of `ehospitalws-1.0.0`).

## Changes

- **`OpenMRSPropertiesUtil`** — `getProperty` is now a genuine optional getter (treats blank as missing, returns the supplied default). Added **`getRequiredProperty(key)`** which throws `IllegalStateException` with a clear *"Set it in openmrs-runtime.properties"* message when a required value is absent or blank.
- **`SmsService`** — reads the four `sms.*` properties with **no placeholder fallback**, logs a clear **WARN at startup** when unconfigured, and **refuses to send** (logs an error and returns `false`) rather than calling the gateway with fake credentials. Kept non-fatal so a missing SMS config does not break module/app startup. Replaced `e.printStackTrace()` with slf4j logging.
- **`SendMessageTask` / `ScheduledAppointmentReminderTask`** — `admin.username` / `admin.password` now use `getRequiredProperty`, so misconfiguration fails loudly within the tasks' existing error handling instead of authenticating as `*****`.
- **`pom.xml`** — added `<tagNameFormat>v@{project.version}</tagNameFormat>` to `maven-release-plugin`.

## Required runtime properties

These must be set in `openmrs-runtime.properties` for SMS / appointment reminders to work:

`sms.api.url`, `sms.api.key`, `sms.partner.id`, `sms.shortcode`, `admin.username`, `admin.password`

## Notes / behavior changes

- The SMS feature is now **disabled (with a logged warning) when unconfigured** rather than appearing to work against a test endpoint.
- The next release tag created by `maven-release-plugin` will be `v<version>` (e.g. `v1.0.0`). This is distinct from prior default-format tags.
- Not compiled locally (no Maven/Java in the dev environment); relying on CI to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)