### PR TITLE
Fix REST API 500 Error when POSTing Orders (testorder, drugorder, etc.)

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ehospitalws/web/resources/OrderResource2_3.java
+++ b/omod/src/main/java/org/openmrs/module/ehospitalws/web/resources/OrderResource2_3.java
@@ -12,8 +12,8 @@ import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.OrderResource2_2;
 
-@Resource(name = RestConstants.VERSION_2 + "/order", supportedClass = Order.class, supportedOpenmrsVersions = {
-        "2.6.* - 9.*" })
+@Resource(name = RestConstants.VERSION_1 + "/order", supportedClass = Order.class, supportedOpenmrsVersions = {
+        "2.6.* - 9.*" }, order = 1)
 public class OrderResource2_3 extends OrderResource2_2 {
 	
 	private String PROCEDURE_ORDER_TYPE_UUID = "4237a01f-29c5-4167-9d8e-96d6e590aa33";


### PR DESCRIPTION
## Issue
https://intellisoftkenya.atlassian.net/browse/SJT-235
## Description
This PR resolves an issue where submitting orders (e.g., `testorder`, `drugorder`, `procedureorder`) via the REST API (`POST /ws/rest/v1/order`) resulted in an HTTP 500 error: 
`type=testorder is not handled by this resource (class org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_2.OrderResource2_2) or any subclass`.
## Root Cause
The `OrderResource2_3` handler (introduced for `ProcedureOrder`) was improperly mapped to `RestConstants.VERSION_2 + "/order"` while simultaneously claiming `supportedClass = Order.class`. 
This caused OpenMRS to delegate all order subclasses to `OrderResource2_3` during startup, effectively stripping the core `OrderResource2_2` of its subclass handlers. Because `OrderResource2_3` was mapped to the `v2` endpoint, standard requests hitting the `v1/order` endpoint fell back to the stripped core resource, which no longer knew how to handle the subclasses and threw an exception.
## Solution
- Modified the `@Resource` annotation in `OrderResource2_3.java` to correctly map to `RestConstants.VERSION_1 + "/order"`.
- Added `order = 1` to the `@Resource` annotation to establish clear resource precedence, resolving the `Two resources with the same name (...) must not have the same order` conflict with the core resource.
With this change, `OrderResource2_3` correctly overrides the core `v1` endpoint and handles all order subclasses without breaking standard OpenMRS REST API functionality.

## ScreenRecord

https://github.com/user-attachments/assets/9f54cbd3-cb37-4026-baa3-b398831ce352

